### PR TITLE
export type MqttParameters from the module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 import type { MqttParameters, FillTopic, CleanTopic } from "./parameters";
 import type { F } from "ts-toolbelt";
 
+export type { MqttParameters } from './parameters'
+
 /**
  * Extract parameters from a topic based on the pattern provided
  * @param pattern Pattern to match against

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,4 @@
-import { clean, exec, extract, fill, matches } from "./index";
+import { clean, exec, extract, fill, matches, MqttParameters } from "./index";
 import { Test } from "ts-toolbelt";
 import test from "node:test";
 // Type Testing
@@ -9,6 +9,7 @@ const { check, checks } = Test;
 const execv = exec("foo/bar/+baz", "foo/bar/test");
 checks([
   check<typeof execv, { baz: string } | null, Test.Pass>(),
+  check<typeof execv, MqttParameters<"foo/bar/+baz"> | null, Test.Pass>(),
   check<typeof execv, { baz: string[] } | null, Test.Fail>(),
 ]);
 


### PR DESCRIPTION
Fixes #9 

When implementing it I realised it was not as useful to be export `FillTopic` and `CleanTopic` too as these ended up just being strings. So I've only exported the `MqttParameters` type.




